### PR TITLE
Support Elasticsearch 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.elasticsearch.plugin.river.eea_rdf</groupId>
   <artifactId>eea-rdf-river-plugin</artifactId>
-  <version>1.4</version>
+  <version>1.4.1-SNAPSHOT</version>
 
   <packaging>jar</packaging>
 
@@ -18,7 +18,7 @@
   </organization>
 
   <properties>
-    <elasticsearch.version>0.90.3</elasticsearch.version>
+    <elasticsearch.version>1.3.2</elasticsearch.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/main/java/org/elasticsearch/river/eea_rdf/RDFRiver.java
+++ b/src/main/java/org/elasticsearch/river/eea_rdf/RDFRiver.java
@@ -1,23 +1,19 @@
 package org.elasticsearch.river.eea_rdf;
 
-import org.elasticsearch.client.Client;
+import java.util.List;
+import java.util.Map;
 
+import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-
-import org.elasticsearch.ElasticSearchIllegalArgumentException;
-
 import org.elasticsearch.river.AbstractRiverComponent;
-import org.elasticsearch.river.eea_rdf.support.Harvester;
-import org.elasticsearch.river.eea_rdf.settings.EEASettings;
 import org.elasticsearch.river.River;
 import org.elasticsearch.river.RiverIndexName;
 import org.elasticsearch.river.RiverName;
 import org.elasticsearch.river.RiverSettings;
-
-import java.util.Map;
-import java.util.List;
+import org.elasticsearch.river.eea_rdf.settings.EEASettings;
+import org.elasticsearch.river.eea_rdf.support.Harvester;
 
 /**
  *
@@ -107,8 +103,8 @@ public class RDFRiver extends AbstractRiverComponent implements River {
 			}
 		}
 		else {
-			throw new	ElasticSearchIllegalArgumentException(
-					"There are no eeaRDF settings in the	river settings");
+			throw new IllegalArgumentException(
+					"There are no eeaRDF settings in the river settings");
 		}
 
 		if(settings.settings().containsKey("index")){


### PR DESCRIPTION
Avoids ClassNotFound on ElasticSearchIllegalArgumentException so it works with ElasticSearch 1.3.2

BTW - why is `target/` checked in to git?