### PR TITLE
Index Performance Improvements by better using Bulk Requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
       <groupId>org.apache.jena</groupId>
       <artifactId>apache-jena-libs</artifactId>
       <type>pom</type>
-      <version>2.10.1</version>
+      <version>2.12.1</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/elasticsearch/river/eea_rdf/support/Harvester.java
+++ b/src/main/java/org/elasticsearch/river/eea_rdf/support/Harvester.java
@@ -691,8 +691,6 @@ public class Harvester implements Runnable {
 	private void harvestWithSelect(QueryExecution qexec) {
 		Model sparqlModel = ModelFactory.createDefaultModel();
 		Graph graph = sparqlModel.getGraph();
-                long startTime =  System.currentTimeMillis();
-                        
 		boolean got500 = true;
 
 		while(got500) {


### PR DESCRIPTION
The current rdf-river-plugin (v1.5.0) indexes documents one by one - which is not efficient, especially for large dataset.

Nevertheless, it does not flush the BulkReqestBuilder instance after request execution, hence it keeps indexing same data again and again. This works ok for small dataset but comes with a lot of cost.

I have tested the latest river plugin (v1.5.0) with only 10,203 triples. It took 25 minutes to index all the documents. But believe it or not, same data took 8 seconds with these new modifications.